### PR TITLE
Add elementl mobile app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.expo
+.DS_Store
+.idea

--- a/App.js
+++ b/App.js
@@ -1,0 +1,40 @@
+import React, { useCallback } from 'react';
+import { View, Image, StyleSheet, Pressable, Vibration } from 'react-native';
+import { Audio } from 'expo-av';
+
+export default function App() {
+  const playSound = useCallback(async () => {
+    const { sound } = await Audio.Sound.createAsync(
+      require('./resources/sound/pebbles.mp3')
+    );
+    await sound.playAsync();
+  }, []);
+
+  const handlePress = async () => {
+    Vibration.vibrate(100);
+    try {
+      await playSound();
+    } catch (e) {
+      console.warn('Unable to play sound', e);
+    }
+  };
+
+  return (
+    <Pressable style={styles.container} onPress={handlePress}>
+      <Image source={require('./resources/image/pebble.png')} style={styles.image} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# elementl
+
+A calming pebble sound app built with Expo React Native. Tapping anywhere plays the sound of pebbles and triggers a short vibration.
+
+## Setup
+
+1. Install [Node.js](https://nodejs.org/) and the Expo CLI:
+   ```bash
+   npm install -g expo-cli
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm start
+   ```
+
+## Assets
+
+`resources/image/pebble.png` and `resources/sound/pebbles.mp3` are placeholders. Replace them with your own pebble image and sound file for the best experience.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,20 @@
+{
+  "expo": {
+    "name": "elementl",
+    "slug": "elementl",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./resources/image/pebble.png",
+    "splash": {
+      "image": "./resources/image/pebble.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "elementl",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "expo-av": "~13.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.3"
+  },
+  "devDependencies": {
+    "expo-cli": "^6.3.0"
+  },
+  "private": true
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,0 @@
-This is a test

--- a/resources/sound/pebbles.mp3
+++ b/resources/sound/pebbles.mp3
@@ -1,0 +1,1 @@
+placeholder sound file


### PR DESCRIPTION
## Summary
- initialize simple Expo project for a calming pebble app
- play a sound and vibrate when the screen is pressed
- provide placeholder pebble image and sound assets
- document setup instructions

## Testing
- `git status --short`
