### PR TITLE
Update to Expo SDK 53.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A calming pebble sound app built with Expo React Native. Tapping anywhere plays 
 
 1. Install [Node.js](https://nodejs.org/) and the Expo CLI:
    ```bash
-   npm install -g expo-cli
+   npm install -g expo-cli@7
    ```
 2. Install dependencies:
    ```bash

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "expo": "^49.0.0",
-    "expo-av": "~13.0.0",
+    "expo": "^53.0.0",
+    "expo-av": "~14.0.0",
     "react": "18.2.0",
-    "react-native": "0.72.3"
+    "react-native": "0.73.0"
   },
   "devDependencies": {
-    "expo-cli": "^6.3.0"
+    "expo-cli": "^7.2.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- bump `expo` to 53.0.0 and update related packages
- document using expo-cli v7 in README

## Testing
- `npm test` *(fails: Missing script)*