### PR TITLE
Revert to original vibration behavior

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { View, Text, Image, StyleSheet, Pressable } from 'react-native';
-import * as Haptics from 'expo-haptics';
+import { View, Text, Image, StyleSheet, Pressable, Vibration } from 'react-native';
 import { Audio } from 'expo-av';
 
 function PlayScreen({ type, onBack }) {
@@ -17,13 +16,7 @@ function PlayScreen({ type, onBack }) {
   }, [soundFile]);
 
   const handlePress = async () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
-    setTimeout(() => {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-    }, 333);
-    setTimeout(() => {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    }, 666);
+    Vibration.vibrate(100);
     try {
       await playSound();
     } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "expo": "^53.0.0",
         "expo-av": "~15.1.4",
-        "expo-haptics": "~14.1.4",
         "react": "19.0.0",
         "react-native": "0.79.2"
       },
@@ -4014,15 +4013,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
-      }
-    },
-    "node_modules/expo-haptics": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-14.1.4.tgz",
-      "integrity": "sha512-QZdE3NMX74rTuIl82I+n12XGwpDWKb8zfs5EpwsnGi/D/n7O2Jd4tO5ivH+muEG/OCJOMq5aeaVDqqaQOhTkcA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "expo": "^53.0.0",
     "expo-av": "~15.1.4",
-    "expo-haptics": "~14.1.4",
     "react": "19.0.0",
     "react-native": "0.79.2"
   },


### PR DESCRIPTION
## Summary
- revert heavy-medium-light haptics back to a single vibration
- remove `expo-haptics` dependency

## Testing
- `npm install --package-lock-only --offline`