### PR TITLE
Fix downward swipe reversal

### DIFF
--- a/App.js
+++ b/App.js
@@ -64,9 +64,7 @@ function PlayScreen({ type, onBack }) {
       onMoveShouldSetPanResponder: () => true,
       onPanResponderGrant: handlePressIn,
       onPanResponderMove: (_, gestureState) => {
-        if (gestureState.dy < 0) {
-          translateY.setValue(gestureState.dy);
-        }
+        translateY.setValue(Math.min(0, gestureState.dy));
       },
       onPanResponderRelease: (_, gestureState) => {
         finishGesture(gestureState.dy < -50);


### PR DESCRIPTION
## Summary
- allow `onPanResponderMove` to follow downward motion so swiping back down cancels the exit animation

## Testing
- `npm test` *(fails: Missing script `test`)*