### PR TITLE
Fix swipe cancel to use velocity

### DIFF
--- a/App.js
+++ b/App.js
@@ -67,10 +67,12 @@ function PlayScreen({ type, onBack }) {
         translateY.setValue(Math.min(0, gestureState.dy));
       },
       onPanResponderRelease: (_, gestureState) => {
-        finishGesture(gestureState.dy < -50);
+        const shouldClose = gestureState.vy < 0 || gestureState.dy < -50;
+        finishGesture(shouldClose);
       },
       onPanResponderTerminate: (_, gestureState) => {
-        finishGesture(gestureState.dy < -50);
+        const shouldClose = gestureState.vy < 0 || gestureState.dy < -50;
+        finishGesture(shouldClose);
       },
     })
   ).current;


### PR DESCRIPTION
## Summary
- improve the swipe gesture logic so cancel/close uses gesture velocity

## Testing
- `npm test` *(fails: Missing script)*